### PR TITLE
gr: pmt: Improving Error Messages for Python usage

### DIFF
--- a/gnuradio-runtime/include/pmt/pmt_serial_tags.h
+++ b/gnuradio-runtime/include/pmt/pmt_serial_tags.h
@@ -42,6 +42,7 @@ enum pst_tags {
     UVI_C32 = 0x0a,
     UVI_C64 = 0x0b,
     PST_COMMENT = 0x3b,
-    PST_COMMENT_END = 0x0a
+    PST_COMMENT_END = 0x0a,
+    PST_PY_STR = 0xc2
 };
 #endif /* INCLUDED_PMT_SERIAL_TAGS_H */

--- a/gnuradio-runtime/lib/pmt/pmt_serialize.cc
+++ b/gnuradio-runtime/lib/pmt/pmt_serialize.cc
@@ -742,8 +742,13 @@ pmt_t deserialize(std::streambuf& sb)
 
         default:
             throw exception("pmt::deserialize: malformed input stream, tag value = ",
-                            from_long(tag));
+                            from_long(tag), ", utag value = ", from_long(utag));
         }
+    }
+
+    case PST_PY_STR: {
+        // Chances are the user is trying to deserialize a Python string, rather than bytes
+        throw exception("pmt::deserialize: malformed input stream, is this a Python 'str' instead of 'bytes'?");
     }
 
     case PST_COMMENT:


### PR DESCRIPTION
<!--- The title of the PR should summarize the change implemented. -->
<!--- Example commit message format: -->
<!--- `module: summary of change` -->
<!--- (leave blank) -->
<!--- `details of what/why/how an issue was addressed` -->
<!--- Keep subject lines to 50 characters (but 72 is a hard limit!) -->
<!--- characters. Refer to the [Revision Control Guidelines](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md#revision-control-guidelines) section of the coding guidelines -->
gr: pmt: Improving Error Messages for Python usage

## Description
<!--- Provide a general summary of your changes in the title above -->
<!--- Why is this change required? What problem does it solve? -->
When trying to deserialize a Python 'str' instead of 'bytes' a vague error is thrown that does not help understand the problem. This should make it more helpful.

## Related Issue
<!--- Refer to any related issues here -->
<!--- If this PR fully addresses an issue, please say "Fixes #1234", -->
<!--- as this will allow Github to automatically close the related Issue -->
Not sure there's an open issue here.

## Which blocks/areas does this affect?
<!--- Include blocks that are affected and some details on what -->
<!--- areas these changes affect, such as performance. -->
PMT operations where deserialization results in a tag error of value 0xc2 (194).
PMT operations where deserialization of uniform vector has an invalid utag error.
Any custom modifications to PMT that use a tag of 0xc2.

## Testing Done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you -->
<!--- ran to see how your change affects other areas of the code, -->
<!--- etc. Then, include justifications for how your tests -->
<!--- demonstrate those affects. -->
None.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [X] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [ ] I have squashed my commits to have one significant change per commit. 
- [X] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [X] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [ ] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [ ] I have added tests to cover my changes, and all previous tests pass.
